### PR TITLE
Carousel browsing

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -97,5 +97,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/angular.json
+++ b/angular.json
@@ -97,8 +97,5 @@
         }
       }
     }
-  },
-  "cli": {
-    "analytics": false
   }
 }

--- a/src/app/components/talk-preview/talk-preview.component.css
+++ b/src/app/components/talk-preview/talk-preview.component.css
@@ -1,6 +1,6 @@
 .talk {
   position: relative;
-  width: 350px;
+  width: 100%;
   display: inline-block;
   float: left;
   border-top: 5px solid #26B3A2;

--- a/src/app/components/talks/talks.component.html
+++ b/src/app/components/talks/talks.component.html
@@ -1,33 +1,76 @@
 <div class="container talks">
   <div [class.hide]="!(talks | async)">
-    <div>
-      <h1>Přednášky</h1>
+    <h1>Přednášky</h1>
+    <section>
       <div>
         Cílem přednáškového maratonu je vzájemná výměna znalostí. Každý zde může mít svoji přednášku, stejně tak lze navštívit přednášky ostatních lektorů. Většina přednášek spadá do určitého tematického okruhu. Máte-li pocit, že Vaše přednáška nespadá do žádného tematického okruhu nebo nějaký tematický okruh chybí, tak prosím kontaktujte organizátory.
-        </div>
-        <div>
-          Každé přednášce můžete dát svůj preferenční bod. Nejvíce žádané přednášky proběhnou v atraktivním čase. Nejméně žádané přednášky mohou být z kapacitních důvodů vyřazeny.
+      </div>
+      <div>
+        Každé přednášce můžete dát svůj preferenční bod. Nejvíce žádané přednášky proběhnou v atraktivním čase. Nejméně žádané přednášky mohou být z kapacitních důvodů vyřazeny.
       </div>
       <br>
-    </div>
-    <div *ngIf="user !== null" class="row m-2 mb-3">
-      <!--<ngb-alert type="warning" [dismissible]="false">-->
-      <!--<strong>-->
-      <!--Registrace přednášek a stravy byla ukončena. V případě dotazů či žádosti o dodatečnou úpravu nás kontaktujte.-->
-      <!--</strong>-->
-      <!--</ngb-alert>-->
-      <button mat-raised-button (click)="openAddTalkDialog()">Přidat přednášku</button>
-    </div>
-    <div class="talkList">
-      <h5 *ngIf="orderedTalksMain.length > 0">Vybrané přednášky</h5>
-      <app-talk-preview *ngFor="let talk of orderedTalksMain" [talk]="talk" [user]="user" [showVotes]="!!(authService.userData | async)"></app-talk-preview>
-
+      <div *ngIf="user !== null" class="row m-2 mb-3">
+        <!--<ngb-alert type="warning" [dismissible]="false">-->
+        <!--<strong>-->
+        <!--Registrace přednášek a stravy byla ukončena. V případě dotazů či žádosti o dodatečnou úpravu nás kontaktujte.-->
+        <!--</strong>-->
+        <!--</ngb-alert>-->
+        <button mat-raised-button (click)="openAddTalkDialog()">Přidat přednášku</button>
+      </div>
+      <br>
       <p>Přednášky budou probíhat už od pátečního večera, do nedělních ranních hodin. Harmonogram přednášek bude hotov pár týdnů před akcí. Pokud byste měli preference o času vaší přednášky, tak neváhejte napsat.</p>
-      <h5 *ngIf="newAddedTalks.length > 0">Nedávno přidané</h5>
-      <app-talk-preview *ngFor="let talk of newAddedTalks" [talk]="talk" [user]="user" [showVotes]="!!(authService.userData | async)"></app-talk-preview>
-      <h5>Všechny přednášky</h5>
-      <app-talk-preview *ngFor="let talk of orderedTalksOthers" [talk]="talk" [user]="user" [showVotes]="!!(authService.userData | async)"></app-talk-preview>
+    </section>
+    <div class="talkList">
+      <section>
+        <h5 *ngIf="orderedTalksMain.length > 0">Vybrané přednášky</h5>
+        <app-talk-preview *ngFor="let talk of orderedTalksMain" [talk]="talk" [user]="user" [showVotes]="!!(authService.userData | async)"></app-talk-preview>
+      </section>
 
+      <section style="background-color: aliceblue; position: relative; padding: 10px; margin: 10px 0">
+        <ng-container *ngIf="{index:0, length: newAddedTalks.length} as locals">
+          <h5 *ngIf="locals.length > 0">Nedávno přidané</h5>
+          <div class="d-flex align-items-center">
+              <button
+                (click)="locals.index = locals.index - 1"
+                [disabled]="locals.index <= 0"
+                class="position-absolute rounded-circle"
+                style="left: 20px; transform: scale(1.5)"
+                *ngIf="locals.length > 3"
+              >
+                <
+              </button>
+              <div
+                class="flex-row d-flex"
+                style="transform: scale(80%)"
+                [style.justify-content]="locals.length > 2 ? 'space-between' : 'space-evenly'"
+              >
+                <app-talk-preview
+                  *ngFor="let talk of newAddedTalks.slice(locals.index, locals.index + 3)"
+                  [talk]="talk"
+                  [user]="user"
+                  [showVotes]="!!(authService.userData | async)"
+                ></app-talk-preview>
+              </div>
+              <button
+                (click)="locals.index = locals.index + 1"
+                [disabled]="locals.index + 3 >= locals.length"
+                class="position-absolute rounded-circle"
+                style="right: 20px; transform: scale(1.5)"
+                *ngIf="locals.length > 3"
+              >
+                >
+              </button>
+          </div>
+        </ng-container>
+    </section>
+
+      <section>
+        <h5>Všechny přednášky</h5>
+        <div style="display: flex; justify-content: space-between; flex-wrap: wrap">
+
+          <app-talk-preview *ngFor="let talk of orderedTalksOthers" [talk]="talk" [user]="user" [showVotes]="!!(authService.userData | async)"></app-talk-preview>
+        </div>
+      </section>
     </div>
   </div>
   <div *ngIf="!(talks | async)">

--- a/src/app/components/talks/talks.component.html
+++ b/src/app/components/talks/talks.component.html
@@ -1,6 +1,7 @@
 <div class="container talks">
   <div [class.hide]="!(talks | async)">
     <h1>Přednášky</h1>
+
     <section>
       <div>
         Cílem přednáškového maratonu je vzájemná výměna znalostí. Každý zde může mít svoji přednášku, stejně tak lze navštívit přednášky ostatních lektorů. Většina přednášek spadá do určitého tematického okruhu. Máte-li pocit, že Vaše přednáška nespadá do žádného tematického okruhu nebo nějaký tematický okruh chybí, tak prosím kontaktujte organizátory.
@@ -20,58 +21,56 @@
       <br>
       <p>Přednášky budou probíhat už od pátečního večera, do nedělních ranních hodin. Harmonogram přednášek bude hotov pár týdnů před akcí. Pokud byste měli preference o času vaší přednášky, tak neváhejte napsat.</p>
     </section>
-    <div class="talkList">
-      <section>
-        <h5 *ngIf="orderedTalksMain.length > 0">Vybrané přednášky</h5>
-        <app-talk-preview *ngFor="let talk of orderedTalksMain" [talk]="talk" [user]="user" [showVotes]="!!(authService.userData | async)"></app-talk-preview>
-      </section>
 
-      <section style="background-color: aliceblue; position: relative; padding: 10px; margin: 10px 0">
-        <ng-container *ngIf="{index:0, length: newAddedTalks.length} as locals">
-          <h5 *ngIf="locals.length > 0">Nedávno přidané</h5>
+    <section>
+      <h5 *ngIf="orderedTalksMain.length > 0">Vybrané přednášky</h5>
+      <app-talk-preview *ngFor="let talk of orderedTalksMain" [talk]="talk" [user]="user" [showVotes]="!!(authService.userData | async)"></app-talk-preview>
+    </section>
+
+    <section class="position-relative p-3" style="background-color: rgb(var(--bs-light-rgb))">
+      <ng-container *ngIf="{ index: 0, length: newAddedTalks.length } as locals">
+        <h5 *ngIf="locals.length > 0">Nedávno přidané</h5>
           <div class="d-flex align-items-center">
-              <button
-                (click)="locals.index = locals.index - 1"
-                [disabled]="locals.index <= 0"
-                class="position-absolute rounded-circle"
-                style="left: 20px; transform: scale(1.5)"
-                *ngIf="locals.length > 3"
+            <button
+              (click)="locals.index = locals.index - 1"
+              [disabled]="locals.index <= 0"
+              class="position-absolute rounded-circle"
+              style="left: 20px; transform: scale(1.5)"
+              *ngIf="locals.length > 3"
+            >
+              <
+            </button>
+            <div
+              class="flex-row d-flex"
+              style="transform: scale(80%)"
+              [style.justify-content]="locals.length > 2 ? 'space-between' : 'space-evenly'"
+            >
+              <app-talk-preview
+                *ngFor="let talk of newAddedTalks.slice(locals.index, locals.index + 3)"
+                [talk]="talk"
+                [user]="user"
+                [showVotes]="!!(authService.userData | async)"
+              ></app-talk-preview>
+            </div>
+            <button
+              (click)="locals.index = locals.index + 1"
+              [disabled]="locals.index + 3 >= locals.length"
+              class="position-absolute rounded-circle"
+              style="right: 20px; transform: scale(1.5)"
+              *ngIf="locals.length > 3"
+            >
               >
-                <
-              </button>
-              <div
-                class="flex-row d-flex"
-                style="transform: scale(80%)"
-                [style.justify-content]="locals.length > 2 ? 'space-between' : 'space-evenly'"
-              >
-                <app-talk-preview
-                  *ngFor="let talk of newAddedTalks.slice(locals.index, locals.index + 3)"
-                  [talk]="talk"
-                  [user]="user"
-                  [showVotes]="!!(authService.userData | async)"
-                ></app-talk-preview>
-              </div>
-              <button
-                (click)="locals.index = locals.index + 1"
-                [disabled]="locals.index + 3 >= locals.length"
-                class="position-absolute rounded-circle"
-                style="right: 20px; transform: scale(1.5)"
-                *ngIf="locals.length > 3"
-              >
-                >
-              </button>
+            </button>
           </div>
         </ng-container>
     </section>
 
-      <section>
-        <h5>Všechny přednášky</h5>
-        <div style="display: flex; justify-content: space-between; flex-wrap: wrap">
-
-          <app-talk-preview *ngFor="let talk of orderedTalksOthers" [talk]="talk" [user]="user" [showVotes]="!!(authService.userData | async)"></app-talk-preview>
-        </div>
-      </section>
-    </div>
+    <section>
+      <h5>Všechny přednášky</h5>
+      <div class="d-flex justify-content-between flex-wrap">
+        <app-talk-preview *ngFor="let talk of orderedTalksOthers" [talk]="talk" [user]="user" [showVotes]="!!(authService.userData | async)"></app-talk-preview>
+      </div>
+    </section>
   </div>
   <div *ngIf="!(talks | async)">
     Načítám

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,3 +22,8 @@ app-talk-preview {
 .mr-auto,.mx-auto {
   margin-right: auto!important
 }
+
+section {
+  margin-bottom: 2rem;
+  margin-top: 2rem;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,6 +13,7 @@
 }
 
 app-talk-preview {
+  width: 30%;
   margin: 20px 5px;
   position: relative;
   display: inline-block;


### PR DESCRIPTION
Separating Newly added talks from the rest of the page by scaling down the talks, centring them to the middle, adding a background and indenting a little.

Preview:
![image](https://user-images.githubusercontent.com/56202269/202896179-911bfa0e-9f45-4241-bc3d-4c80fd7bbab1.png)

Ref #21 